### PR TITLE
fix: add jest types in dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.9.0",
     "@types/wol": "^1.0.4",
     "cors": "^2.8.5",
@@ -35,7 +36,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
-    "@types/jest": "^29.5.14",
     "eslint": "^9.19.0",
     "globals": "^15.14.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
Fast fix for broken production mode, it should not rely
on jest types to be present to function